### PR TITLE
Rebuild branch-main as multi-arch (amd64/arm64)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# Rebuild to publish a multi-arch (amd64/arm64) branch-main image so ECS tasks
+# can run on Graviton (ARM64). See cloudnativedaysjp/dreamkast-infra ARM switch.
 FROM golang:1.25-bookworm AS builder
 
 WORKDIR /root


### PR DESCRIPTION
## 概要

`dreamkast-otelcol:branch-main` を再ビルドして **マルチアーチ (amd64/arm64) manifest** を再発行します。

## 背景

ECR 上の `branch-main` イメージは **2025-12-12** が最終ビルドで、共通ビルドワークフローがネイティブ ARM64 マルチアーチに対応した [reusable-workflows#70](https://github.com/cloudnativedaysjp/reusable-workflows/pull/70)（2026-04-08）**より前**です。そのため amd64 の descriptor しか持っていません。

dreamkast-infra で ECS Fargate タスクを ARM64 (Graviton) に切り替えたところ、otelcol サイドカーが pull できず以下で失敗しました:

```
CannotPullContainerError: ... image Manifest does not contain descriptor matching platform 'linux/arm64/v8'
```

## 変更内容

`on-push-main` の再ビルドをトリガーするため Dockerfile にコメントを追加するだけです（イメージ内容は不変）。マージ後、`branch-main` がマルチアーチ manifest として stg(us-west-2) / prod(ap-northeast-1) の ECR に再 push されます。

## マージ後

dreamkast-infra 側で ARM への切り替え（stg）を再デプロイすれば、otelcol サイドカーを arm64 で pull できるようになります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)