### PR TITLE
resourceprocessorの追加

### DIFF
--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -18,6 +18,7 @@ receivers:
 processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.155.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.155.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.155.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.155.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.155.0
   - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.155.0

--- a/otelcol/components.go
+++ b/otelcol/components.go
@@ -18,6 +18,7 @@ import (
 	healthcheckextension "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension"
 	attributesprocessor "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor"
 	probabilisticsamplerprocessor "github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor"
+	resourceprocessor "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor"
 	resourcedetectionprocessor "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor"
 	tailsamplingprocessor "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
 	batchprocessor "go.opentelemetry.io/collector/processor/batchprocessor"
@@ -98,6 +99,7 @@ func components() (otelcol.Factories, error) {
 	factories.Processors, err = otelcol.MakeFactoryMap[processor.Factory](
 		attributesprocessor.NewFactory(),
 		probabilisticsamplerprocessor.NewFactory(),
+		resourceprocessor.NewFactory(),
 		resourcedetectionprocessor.NewFactory(),
 		tailsamplingprocessor.NewFactory(),
 		batchprocessor.NewFactory(),
@@ -108,6 +110,7 @@ func components() (otelcol.Factories, error) {
 	factories.ProcessorModules = makeModulesMap(factories.Processors, map[component.Type]string{
 		attributesprocessor.NewFactory().Type(): "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.155.0",
 		probabilisticsamplerprocessor.NewFactory().Type(): "github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.155.0",
+		resourceprocessor.NewFactory().Type(): "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.155.0",
 		resourcedetectionprocessor.NewFactory().Type(): "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.155.0",
 		tailsamplingprocessor.NewFactory().Type(): "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.155.0",
 		batchprocessor.NewFactory().Type(): "go.opentelemetry.io/collector/processor/batchprocessor v0.155.0",

--- a/otelcol/go.mod
+++ b/otelcol/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.155.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.155.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.155.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.155.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.155.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.155.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.155.0

--- a/otelcol/go.sum
+++ b/otelcol/go.sum
@@ -614,6 +614,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisti
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.155.0/go.mod h1:pV7/g0+QhcCn99AquCuUqwv86o/rHAV17ltA2cJG120=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.155.0 h1:MCnRnAxhdCRAMO8y8tQr301STwzsf30cet/sm2ENk2I=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.155.0/go.mod h1:3UHjMcfak812cru5sV4XFIcb+1aGs9Mz9EEfwDY90n0=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.155.0 h1:FXptP6AvYsom77QecaSJQcC9vTrVejpmnrbCHpUsWns=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.155.0/go.mod h1:cCujio3QWXzAanOP+tTIsDRaZOjm5/RJeTm7rBiNVAo=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.155.0 h1:4dgIqbcuWxq2SbrVXNb8gyXiEOVu3MSFzSpZEP9IqwA=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.155.0/go.mod h1:XDB6fYmjiUDLvAoZQ1wX+J9v9cV8x9n9oP+wQ+yxflI=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.155.0 h1:iwbI95bt0uODjbRrrnBVpEd1+2UDsPS2mG01Q9+c1Ps=


### PR DESCRIPTION
mackerelではresourceにサービス名を設定しないと、`unkown_service` になるっぽい。
なので、resource processor を設定可能にして、attributeと同じような情報を設定したい。

https://github.com/cloudnativedaysjp/dreamkast-infra/blob/4def5b5a5aee4b9d493848b583995b18152bbc39/ecspresso/stg/dreamkast/files/otelcol-config.yaml#L24

resourcedetection processor があるので、ENVに経由で設定しても良いが、otelcol-config.yaml内で設定できていた方が設定がまとまっててよさそう。